### PR TITLE
Fix latency issue in watchdog

### DIFF
--- a/ATCBot/Watchdog.cs
+++ b/ATCBot/Watchdog.cs
@@ -41,7 +41,7 @@ namespace ATCBot
                 return;
             }
 
-            if (DateTime.Now - lastUpdate > TimeSpan.FromSeconds(waitTime))
+            if (DateTime.Now - lastUpdate > TimeSpan.FromSeconds(waitTime) * 2) //We wait 2 full cycles to negate any possible latency issues that would cause it to be counted as a miss
             {
                 skippedBeats++;
                 switch (skippedBeats)


### PR DESCRIPTION
- The watchdog will now wait 2 cycles before declaring a skipped heartbeat to avoid issues where latency would cause it to deem every heartbeat as skipped and then reset.