### PR TITLE
Another test for watchdog revival

### DIFF
--- a/ATCBot/LobbyHandler.cs
+++ b/ATCBot/LobbyHandler.cs
@@ -40,7 +40,11 @@ namespace ATCBot
         /// </summary>
         public static bool triedLoggingIn;
 
-        private SteamClient client;
+        /// <summary>
+        /// The Steam client currently in use.
+        /// </summary>
+        public SteamClient client;
+
         private CallbackManager manager;
         private SteamUser user;
         private SteamMatchmaking matchmaking;

--- a/ATCBot/Watchdog.cs
+++ b/ATCBot/Watchdog.cs
@@ -60,6 +60,7 @@ namespace ATCBot
                             else
                             {
                                 Log.LogError($"Watchdog has detected a skipped heartbeat for the 5th time in a row! Trying to revive the query timer...", source: "Watchdog", announce: true);
+                                Program.lobbyHandler.client.Disconnect();
                                 Program.lobbyHandler = new(program);
                                 _ = Program.lobbyHandler.QueryTimer(LobbyHandler.queryToken.Token);
                                 Program.lobbyHandler.ResetQueryTimer();


### PR DESCRIPTION
- The watchdog will explicitly disconnect the Steamkit client as a test of fixing a hanged query.