### PR TITLE
Refactor configuration

### DIFF
--- a/ATCBot/Commands/SetConfig.cs
+++ b/ATCBot/Commands/SetConfig.cs
@@ -21,11 +21,14 @@ namespace ATCBot.Commands
             .AddChoice("jetbornelobbyid", 3)
             .AddChoice("systemmessageid", 4)
             .AddChoice("statusmessageid", 5)
-            .AddChoice("saveconfig", 6)
-            .AddChoice("botroleid", 7)
-            .AddChoice("autoquery", 8)
+            .AddChoice("botroleid", 6)
+            .AddChoice("autoquery", 7)
             .WithType(ApplicationCommandOptionType.Integer)
-        ).AddOption("value", ApplicationCommandOptionType.String, "The value to set the config item to.");
+        ).AddOption(new SlashCommandOptionBuilder()
+            .WithName("value")
+            .WithDescription("The value to set.")
+            .WithRequired(true)
+            .WithType(ApplicationCommandOptionType.String));
 
         public override string Action(SocketSlashCommand command)
         {
@@ -100,23 +103,6 @@ namespace ATCBot.Commands
                         }
 
                     case 6:
-                        successful = bool.TryParse((string)command.Data.Options.ElementAt(1).Value, out boolValue);
-                        if (successful)
-                        {
-                            if (boolValue)
-                            {
-                                Program.config.shouldSave = true;
-                                return "Will save config on shutting down!";
-                            }
-                            else
-                            {
-                                Program.config.shouldSave = false;
-                                return "Will not save config on shutting down!";
-                            }
-                        }
-                        else return "Sorry, I couldn't translate your input to a true/false boolean.";
-
-                    case 7:
                         successful = ulong.TryParse((string)command.Data.Options.ElementAt(1).Value, out value);
                         if (successful)
                         {
@@ -128,7 +114,7 @@ namespace ATCBot.Commands
                             return "Sorry, I couldn't translate your input to an integer.";
                         }
 
-                    case 8:
+                    case 7:
                         successful = bool.TryParse((string) command.Data.Options.ElementAt(1).Value, out boolValue);
                         if (successful)
                         {

--- a/ATCBot/Program.cs
+++ b/ATCBot/Program.cs
@@ -441,13 +441,6 @@ namespace ATCBot
             if (forceDontSaveConfig)
                 return;
             Console.WriteLine("------");
-            if (config.shouldSave)
-            {
-                Console.WriteLine("Saving config!");
-                config.Save(false);
-            }
-            else
-                Console.WriteLine("Not saving config!");
 
             try
             {


### PR DESCRIPTION
Configuration now uses a custom struct that declares its type, this is done to make it more modular and allow for the main point: saving after every config edit so that an unexpected shutdown does not discard all changes to the config.

**This changes the way the config is saved, meaning that any versions of the bot using this system will need to have their configurations wiped, otherwise it will not run.**