### PR TITLE
Change behavior of refresh

### DIFF
--- a/ATCBot/Commands/Refresh.cs
+++ b/ATCBot/Commands/Refresh.cs
@@ -10,14 +10,14 @@ namespace ATCBot.Commands
         public override string Name { get; set; } = "refresh";
         public override SlashCommandBuilder Builder { get; set; } = new SlashCommandBuilder()
             .WithName("refresh")
-            .WithDescription("Force the bot to delete previous messages. Requires permission.");
+            .WithDescription("Force a manual update to the lobby messages. Requires permission.");
 
         public override string Action(SocketSlashCommand command)
         {
             if (HasPerms(command.User))
             {
-                Program.shouldRefresh = true;
-                return "Will refresh on the next update!";
+                Program.lobbyHandler.ResetQueryTimer();
+                return "Initiated a manual update!";
             }
             else return "Sorry, you don't have the permissions to use this command!";
         }

--- a/ATCBot/LobbyHandler.cs
+++ b/ATCBot/LobbyHandler.cs
@@ -70,8 +70,12 @@ namespace ATCBot
             SetupSteam();
         }
 
+        /// <summary>
+        /// Cancels the current running query timer via its token, recreates that token, and restarts the query timer based off that new token.
+        /// </summary>
         public async void ResetQueryTimer()
         {
+            Log.LogDebug("Query timer was reset.");
             queryToken.Cancel();
             queryToken = new();
             await Task.Delay(Program.config.delay);

--- a/ATCBot/Program.cs
+++ b/ATCBot/Program.cs
@@ -59,11 +59,6 @@ namespace ATCBot
         public static bool shouldShutdown = false;
 
         /// <summary>
-        /// Whether or not we should refresh the messages.
-        /// </summary>
-        public static bool shouldRefresh = false;
-
-        /// <summary>
         /// Represents the current operational status of the bot.
         /// </summary>
         public enum Status
@@ -180,8 +175,6 @@ namespace ATCBot
                 Log.LogWarning("Status message channel ID is not set!", "Status Embed Builder");
             else
                 await UpdateStatusMessage();
-
-            shouldRefresh = false;
         }
 
         /// <summary>
@@ -197,20 +190,6 @@ namespace ATCBot
             {
                 Log.LogWarning("VTOL Lobby Channel ID is incorrect!", "VTOL Embed Builder", true);
                 return;
-            }
-
-            if (shouldRefresh)
-            {
-                try
-                {
-                    await vtolChannel.DeleteMessageAsync(config.vtolLastMessageId);
-                    Log.LogInfo("Deleted VTOL message!");
-                }
-                catch (Discord.Net.HttpException e)
-                {
-                    Log.LogError("Couldn't delete VTOL message!", e, "VTOL Embed Builder", true);
-                    updating = false;
-                }
             }
 
             if (config.vtolLastMessageId != 0 && await vtolChannel.GetMessageAsync(config.vtolLastMessageId) != null)
@@ -248,20 +227,6 @@ namespace ATCBot
                 return;
             }
 
-            if (shouldRefresh)
-            {
-                try
-                {
-                    await jetborneChannel.DeleteMessageAsync(config.jetborneLastMessageId);
-                    Log.LogInfo("Deleted JBR message!");
-                }
-                catch (Discord.Net.HttpException e)
-                {
-                    Log.LogError("Couldn't delete JBR message!", e, "JBR Embed Builder", true);
-                    updating = false;
-                }
-            }
-
             if (config.jetborneLastMessageId != 0 && await jetborneChannel.GetMessageAsync(config.jetborneLastMessageId) != null)
             {
                 await jetborneChannel.ModifyMessageAsync(config.jetborneLastMessageId, m => m.Embed = jetborneEmbed.Build());
@@ -295,20 +260,6 @@ namespace ATCBot
             {
                 Log.LogWarning("Status channel ID is incorrect!", "Status Embed Builder");
                 return;
-            }
-
-            if (shouldRefresh)
-            {
-                try
-                {
-                    await statusChannel.DeleteMessageAsync(config.statusLastMessageId);
-                    Log.LogInfo("Deleted JBR message!");
-                }
-                catch (Discord.Net.HttpException e)
-                {
-                    Log.LogError("Couldn't delete status message!", e, "Status Embed Builder", true);
-                    updating = false;
-                }
             }
 
             if (config.statusLastMessageId != 0 && await statusChannel.GetMessageAsync(config.statusLastMessageId) != null)


### PR DESCRIPTION
- Refresh, instead of deleting all messages, now forces a manual update.

Because anyone with access to refresh should be able to delete the messages manually, at which point the bot will remake them itself, the refresh command is redundant. Now, this can be used to force a new update for any reason.