### PR TITLE
Watchdog will cease alert status if revived

### DIFF
--- a/ATCBot/Watchdog.cs
+++ b/ATCBot/Watchdog.cs
@@ -75,6 +75,11 @@ namespace ATCBot
             {
                 Log.LogDebug("Watchdog reports an acceptable heartbeat.", "Watchdog");
                 skippedBeats = 0;
+                if(triedRestart)
+                {
+                    triedRestart = false;
+                    Log.LogInfo("Watchdog seems to have successfully defibrillated the queries!", "Watchdog", true);
+                }
             }
 
             string AddOrdinal(int n)


### PR DESCRIPTION
- If the watchdog detects it has successfully revived queries, then it will allow another fail before pulling the plug. In other words, only if it still doesn't detect any queries after trying to revive will it crash the application.