### PR TITLE
Make system message logging modular

### DIFF
--- a/ATCBot/Commands/SetConfig.cs
+++ b/ATCBot/Commands/SetConfig.cs
@@ -45,7 +45,7 @@ namespace ATCBot.Commands
                         if (successful)
                         {
                             Program.config.delay = (int)value;
-                            Log.LogInfo("Resetting query method because our delay has changed...", "SetConfig Handler", true);
+                            Log.LogInfo("Resetting query method because our delay has changed...", "SetConfig Handler", Config.SystemMessageConfigOptions.Queries);
                             Program.lobbyHandler.ResetQueryTimer();
                             return $"Successfully set delay to {value} seconds!";
                         }

--- a/ATCBot/Commands/SetSystemMessageConfig.cs
+++ b/ATCBot/Commands/SetSystemMessageConfig.cs
@@ -1,0 +1,67 @@
+﻿using Discord;
+using Discord.WebSocket;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using options = ATCBot.Config.SystemMessageConfigOptions;
+
+namespace ATCBot.Commands
+{
+    internal class SetSystemMessageConfig : Command
+    {
+        public override string Name { get; set; } = "setsystemmessageconfig";
+        public override SlashCommandBuilder Builder { get; set; } = new SlashCommandBuilder()
+            .WithName("setsystemmessageconfig")
+            .WithDescription("Change what system messages should be sent. Requires permission.")
+            .AddOption(new SlashCommandOptionBuilder()
+                .WithName("Type")
+                .WithDescription("The type of message to edit.")
+                .WithRequired(true)
+                .WithType(ApplicationCommandOptionType.Integer)
+                .AddChoice("ConnectionStatus", 0)
+                .AddChoice("Queries", 1)
+                .AddChoice("CommandReceived", 2)
+                .AddChoice("WatchdogWarnings", 3)
+                .AddChoice("Info", 4)
+                .AddChoice("Warning", 5)
+                .AddChoice("Error", 6)
+                .AddChoice("Verbose", 7)
+                .AddChoice("Debug", 8))
+            .AddOption(new SlashCommandOptionBuilder()
+                .WithName("Value")
+                .WithDescription("What to set this type to.")
+                .WithRequired(true)
+                .WithType(ApplicationCommandOptionType.Integer)
+                .AddChoice("Enabled", 1)
+                .AddChoice("Disabled", 2));
+
+        public override string Action(SocketSlashCommand command)
+        {
+            if(HasPerms(command.User))
+            {
+                int type = Convert.ToInt32(command.Data.Options.First());
+                options option = type switch
+                {
+                    0 => options.ConnectionStatus,
+                    1 => options.Queries,
+                    2 => options.CommandReceived,
+                    3 => options.WatchdogWarnings,
+                    4 => options.Info,
+                    5 => options.Warning,
+                    6 => options.Error,
+                    7 => options.Verbose,
+                    8 => options.Debug,
+                    _ => throw new Exception("Impossible argument!")
+                };
+                bool setting = Convert.ToBoolean(command.Data.Options.ElementAt(1));
+                Program.config.systemMessagesConfig.Value[option] = setting;
+                return $"Successfully {(setting ? "enabled" : "disabled")} \"{option}\" option!";
+            }
+            else return "Sorry, you don't have the permissions to use this command!";
+        }
+    }
+}

--- a/ATCBot/Commands/SetSystemMessageConfig.cs
+++ b/ATCBot/Commands/SetSystemMessageConfig.cs
@@ -18,7 +18,7 @@ namespace ATCBot.Commands
             .WithName("setsystemmessageconfig")
             .WithDescription("Change what system messages should be sent. Requires permission.")
             .AddOption(new SlashCommandOptionBuilder()
-                .WithName("Type")
+                .WithName("type")
                 .WithDescription("The type of message to edit.")
                 .WithRequired(true)
                 .WithType(ApplicationCommandOptionType.Integer)
@@ -32,18 +32,18 @@ namespace ATCBot.Commands
                 .AddChoice("Verbose", 7)
                 .AddChoice("Debug", 8))
             .AddOption(new SlashCommandOptionBuilder()
-                .WithName("Value")
+                .WithName("value")
                 .WithDescription("What to set this type to.")
                 .WithRequired(true)
                 .WithType(ApplicationCommandOptionType.Integer)
                 .AddChoice("Enabled", 1)
-                .AddChoice("Disabled", 2));
+                .AddChoice("Disabled", 0));
 
         public override string Action(SocketSlashCommand command)
         {
             if(HasPerms(command.User))
             {
-                int type = Convert.ToInt32(command.Data.Options.First());
+                int type = Convert.ToInt32(command.Data.Options.First().Value);
                 options option = type switch
                 {
                     0 => options.ConnectionStatus,
@@ -55,9 +55,9 @@ namespace ATCBot.Commands
                     6 => options.Error,
                     7 => options.Verbose,
                     8 => options.Debug,
-                    _ => throw new Exception("Impossible argument!")
+                    _ => throw new Exception("Impossible option!")
                 };
-                bool setting = Convert.ToBoolean(command.Data.Options.ElementAt(1));
+                bool setting = Convert.ToInt32(command.Data.Options.ElementAt(1).Value) == 1 ? true : false;
                 Program.config.systemMessagesConfig.Value[option] = setting;
                 return $"Successfully {(setting ? "enabled" : "disabled")} \"{option}\" option!";
             }

--- a/ATCBot/Commands/_Command.cs
+++ b/ATCBot/Commands/_Command.cs
@@ -23,7 +23,7 @@ namespace ATCBot.Commands
             {
                 if (!warnedBotRoleNotSet)
                 {
-                    Log.LogDebug("Bot role ID not set, defaulting to Manage Server for permission checking...", announce: true);
+                    Log.LogDebug("Bot role ID not set, defaulting to Manage Server for permission checking...");
                     warnedBotRoleNotSet = true;
                 }
 

--- a/ATCBot/Commands/_CommandBuilder.cs
+++ b/ATCBot/Commands/_CommandBuilder.cs
@@ -36,7 +36,7 @@ namespace ATCBot.Commands
 
             if (config.shouldBuildCommands)
             {
-                Log.LogInfo("Building slash commands, they probably won't work for the next hour!", "Slash Command Builder", true);
+                Log.LogInfo("Building slash commands, they probably won't work for the next hour!", "Slash Command Builder", Config.SystemMessageConfigOptions.Critical);
                 config.shouldBuildCommands = false;
             }
             else

--- a/ATCBot/Commands/_CommandHandler.cs
+++ b/ATCBot/Commands/_CommandHandler.cs
@@ -28,7 +28,7 @@ namespace ATCBot.Commands
 
                 string logMessage = $"Received slash command \"{command.Data.Name}\"{(argsAsText == "" ? "" : $" with parameters \"{argsAsText}\"")}.";
                 string logSource = $"{command.User.Username} in {command.Channel.Name}";
-                Log.LogInfo(logMessage, logSource, true);
+                Log.LogInfo(logMessage, logSource, Config.SystemMessageConfigOptions.CommandReceived);
                 Command c = Command.AllCommands.Find(c => c.Name.Equals(command.Data.Name));
                 await command.RespondAsync(c.Action(command));
             }

--- a/ATCBot/Config.cs
+++ b/ATCBot/Config.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Converters;
 using System;
 using System.Reflection;
 using System.IO;
+using System.Collections.Generic;
 
 namespace ATCBot
 {
@@ -24,7 +25,7 @@ namespace ATCBot
         public ConfigValue<string> token;
 
         /// <summary>
-        /// The current verbosity of the logs.
+        /// The current verbosity of the logs. Not to be confused with <see cref="systemMessagesConfig"/>.
         /// </summary>
         public ConfigValue<Log.LogVerbosity> logVerbosity;
 
@@ -105,6 +106,77 @@ namespace ATCBot
         public ConfigValue<int> steamTimeout = 1;
 
         /// <summary>
+        /// A set of configuration options for what system messages should be sent.
+        /// </summary>
+        public ConfigValue<Dictionary<SystemMessageConfigOptions, bool>> systemMessagesConfig = defaultSystemMessageConfigOptions;
+
+        /// <summary>
+        /// Represents all available configuration options for system messages.
+        /// </summary>
+        public enum SystemMessageConfigOptions
+        {
+            /// <summary>
+            /// For logs that should intentionally never be output.
+            /// </summary>
+            Silent,
+
+            /// <summary>
+            /// All logs that don't match any other categories.
+            /// </summary>
+            Default,
+
+            /// <summary>
+            /// Sent whenever the bot/SteamKit account connect or disconnect.
+            /// </summary>
+            ConnectionStatus,
+
+            /// <summary>
+            /// Sent whenever something happend regarding queries.
+            /// </summary>
+            Queries,
+
+            /// <summary>
+            /// Sent whenever a command is received.
+            /// </summary>
+            CommandReceived,
+
+            /// <summary>
+            /// Sent if the watchdog detects a skipped heartbeat, instead of only when it flatlines.
+            /// </summary>
+            WatchdogWarnings,
+
+            /// <summary>
+            /// Sent for all informational messages.
+            /// </summary>
+            Info,
+
+            /// <summary>
+            /// Sent for all warning messages.
+            /// </summary>
+            Warning,
+
+            /// <summary>
+            /// Sent for all errors. Critical errors are always sent.
+            /// </summary>
+            Error,
+
+            /// <summary>
+            /// Sent for all verbose messages.
+            /// </summary>
+            Verbose,
+
+            /// <summary>
+            /// Sent for all debug messages.
+            /// </summary>
+            Debug,
+
+            /// <summary>
+            /// Internal value for system-critical messages that must be sent. Should never be disabled.
+            /// </summary>
+            Critical
+        }
+
+        /// <summary>
         /// Represents a singular config value of type <typeparamref name="T"/>.
         /// </summary>
         /// <remarks>Will automatically save <see cref="Current"/> to disk when edited.</remarks>
@@ -160,6 +232,24 @@ namespace ATCBot
         private static readonly string saveFile = Path.Combine(saveDirectory, @"config.cfg");
 
         private static bool loading;
+
+        private static Dictionary<SystemMessageConfigOptions, bool> defaultSystemMessageConfigOptions = new Dictionary<SystemMessageConfigOptions, bool>()
+        {
+            {SystemMessageConfigOptions.Silent, false },
+            {SystemMessageConfigOptions.Default, false },
+            {SystemMessageConfigOptions.Critical, true },
+
+            {SystemMessageConfigOptions.ConnectionStatus, true },
+            {SystemMessageConfigOptions.Queries, true },
+            {SystemMessageConfigOptions.CommandReceived, true },
+            {SystemMessageConfigOptions.WatchdogWarnings, false },
+            {SystemMessageConfigOptions.Info, true },
+            {SystemMessageConfigOptions.Warning, true },
+            {SystemMessageConfigOptions.Error, true },
+            {SystemMessageConfigOptions.Verbose, false },
+            {SystemMessageConfigOptions.Debug, false }
+
+        };
 
         /// <summary>
         /// Saves the current config to <see cref="saveFile"/>.

--- a/ATCBot/LobbyHandler.cs
+++ b/ATCBot/LobbyHandler.cs
@@ -53,7 +53,7 @@ namespace ATCBot
         {
             if (Program.updating)
             {
-                if(triedLoggingIn) Log.LogInfo("Updating lobbies...", "Lobby Handler");
+                if(triedLoggingIn) Log.LogInfo("Updating lobbies...", "Lobby Handler", Config.SystemMessageConfigOptions.Silent);
                 manager.RunWaitCallbacks(TimeSpan.FromSeconds(Program.config.steamTimeout));
                 await GetLobbies();
                 await program.UpdateInformation();
@@ -126,10 +126,7 @@ namespace ATCBot
             });
         }
 
-        private void OnDisconnected(SteamClient.DisconnectedCallback callback)
-        {
-            Log.LogWarning("Disconnected from Steam! This usually means a problem with Steam's servers!", "Lobby Handler", true);
-        }
+        private void OnDisconnected(SteamClient.DisconnectedCallback callback) => Log.LogWarning("Disconnected from Steam! This usually means a problem with Steam's servers!", "Lobby Handler", Config.SystemMessageConfigOptions.ConnectionStatus);
 
         private void OnLoggedOn(SteamUser.LoggedOnCallback callback)
         {
@@ -141,34 +138,34 @@ namespace ATCBot
             if (hasSteamGuard)
             {
                 Log.LogWarning($"Looks like Steam does not trust this machine yet. " +
-                    $"You have been emailed an auth code, please input that into steam.json and re-run the program.", "Lobby Handler", true);
+                    $"You have been emailed an auth code, please input that into steam.json and re-run the program.", "Lobby Handler", Config.SystemMessageConfigOptions.ConnectionStatus);
                 Environment.Exit(1);
             }
 
             if (hasF2A)
             {
-                Log.LogWarning("Looks like you have Steam Guard enabled, please enter the current code into steam.json and re-run the program.", "Lobby Handler", true);
+                Log.LogWarning("Looks like you have Steam Guard enabled, please enter the current code into steam.json and re-run the program.", "Lobby Handler", Config.SystemMessageConfigOptions.ConnectionStatus);
                 Environment.Exit(1);
             }
 
             if (callback.Result != EResult.OK)
             {
-                Log.LogWarning($"Failed to log into Steam because: {callback.Result} {callback.ExtendedResult}", "Lobby Handler", true);
+                Log.LogWarning($"Failed to log into Steam because: {callback.Result} {callback.ExtendedResult}", "Lobby Handler", Config.SystemMessageConfigOptions.ConnectionStatus);
                 if (callback.Result.ToString().Equals("TryAnotherCM")) {
-                    Log.LogInfo("Will try to log in again, since this might not be our fault.", "Lobby Handler", true);
+                    Log.LogInfo("Will try to log in again, since this might not be our fault.", "Lobby Handler", Config.SystemMessageConfigOptions.ConnectionStatus);
                     SetupSteam();
                     return;
                 }
                 else Environment.Exit(1);
             }
 
-            Log.LogInfo("Logged into Steam account!", "Lobby Handler", true);
+            Log.LogInfo("Logged into Steam account!", "Lobby Handler", Config.SystemMessageConfigOptions.ConnectionStatus);
             loggedIn = true;
         }
 
         private void OnLoggedOff(SteamUser.LoggedOffCallback callback)
         {
-            Log.LogWarning("Logged out of Steam!", "Lobby Handler", true);
+            Log.LogWarning("Logged out of Steam!", "Lobby Handler", Config.SystemMessageConfigOptions.ConnectionStatus);
             loggedIn = false;
         }
 
@@ -241,7 +238,7 @@ namespace ATCBot
             }
             else
             {
-                Log.LogWarning("Raw VTOL VR lobbies was null! This could mean we were logged out of Steam for some reason!", "VTOL Lobby Getter", true);
+                Log.LogWarning("Raw VTOL VR lobbies was null! This could mean we were logged out of Steam for some reason!", "VTOL Lobby Getter", Config.SystemMessageConfigOptions.Queries);
                 vtolLobbies = new List<VTOLLobby>();
             }
 
@@ -251,7 +248,7 @@ namespace ATCBot
             }
             else
             {
-                Log.LogWarning("Raw JBR lobbies was null! This could mean we were logged out of Steam for some reason!", "JBR Lobby Getter", true);
+                Log.LogWarning("Raw JBR lobbies was null! This could mean we were logged out of Steam for some reason!", "JBR Lobby Getter", Config.SystemMessageConfigOptions.Queries);
                 jetborneLobbies = new List<JetborneLobby>();
             }
         }

--- a/ATCBot/Program.cs
+++ b/ATCBot/Program.cs
@@ -103,7 +103,7 @@ namespace ATCBot
             }
             catch (Exception e)
             {
-                Log.LogCritical($"Fatal error! Ejecting! {e.Message}", e, "Main", true);
+                Log.LogCritical($"Fatal error! Ejecting! {e.Message}", e, "Main");
                 Environment.Exit(1);
             }
         }
@@ -128,7 +128,7 @@ namespace ATCBot
 
         private static Task DiscordLog(LogMessage message)
         {
-            Log.LogCustom(message);
+            Log.LogCustom(message, Config.SystemMessageConfigOptions.ConnectionStatus);
             return Task.CompletedTask;
         }
 
@@ -188,7 +188,7 @@ namespace ATCBot
 
             if (vtolChannel == null)
             {
-                Log.LogWarning("VTOL Lobby Channel ID is incorrect!", "VTOL Embed Builder", true);
+                Log.LogWarning("VTOL Lobby Channel ID is incorrect!", "VTOL Embed Builder", Config.SystemMessageConfigOptions.Critical);
                 return;
             }
 
@@ -206,7 +206,7 @@ namespace ATCBot
                 }
                 catch (Discord.Net.HttpException e)
                 {
-                    Log.LogError("Couldn't send VTOL message!", e, "VTOL Embed Builder", true);
+                    Log.LogError("Couldn't send VTOL message!", e, "VTOL Embed Builder");
                     updating = false;
                 }
             }
@@ -241,7 +241,7 @@ namespace ATCBot
                 }
                 catch (Discord.Net.HttpException e)
                 {
-                    Log.LogError("Couldn't send JBR message!", e, "JBR Embed Builder", true);
+                    Log.LogError("Couldn't send JBR message!", e, "JBR Embed Builder");
                     updating = false;
                 }
             }
@@ -276,7 +276,7 @@ namespace ATCBot
                 }
                 catch (Discord.Net.HttpException e)
                 {
-                    Log.LogError("Couldn't send status message!", e, "Status Embed Builder", true);
+                    Log.LogError("Couldn't send status message!", e, "Status Embed Builder");
                     updating = false;
                 }
             }
@@ -293,7 +293,7 @@ namespace ATCBot
                 {
                     if (lobby.OwnerName == string.Empty || lobby.LobbyName == string.Empty || lobby.ScenarioName == string.Empty)
                     {
-                        Log.LogWarning("Invalid lobby state!", "VTOL Embed Builder", true);
+                        Log.LogWarning("Invalid lobby state!", "VTOL Embed Builder");
                         continue;
                     }
                     string content = $"{lobby.ScenarioName}\n{lobby.PlayerCount}/{lobby.MaxPlayers} Players\nv{lobby.GameVersion}{(lobby.Feature == VTOLLobby.FeatureType.m ? " *(Modded)*" : "")}";
@@ -351,12 +351,12 @@ namespace ATCBot
 
         async Task ClientReady()
         {
-            Log.LogInfo("Ready!", "Discord Client", true);
+            Log.LogInfo("Ready!", "Discord Client", Config.SystemMessageConfigOptions.ConnectionStatus);
             //We check the version here so that it outputs to the system channel
             if (!await Version.CheckVersion())
             {
                 Log.LogWarning($"Version mismatch! Please update ATCBot when possible. Local version: " +
-                    $"{Version.LocalVersion} - Remote version: {Version.RemoteVersion}", "Version Checker", true);
+                    $"{Version.LocalVersion} - Remote version: {Version.RemoteVersion}", "Version Checker");
             }
 
             commandHandler = new();
@@ -376,7 +376,7 @@ namespace ATCBot
 
             if(config.autoQuery)
             {
-                Log.LogInfo("Autoquery is enabled, beginning queries.", announce: true);
+                Log.LogInfo("Autoquery is enabled, beginning queries.", systemMessageOption: Config.SystemMessageConfigOptions.Queries);
                 updating = true;
             }
         }
@@ -388,7 +388,7 @@ namespace ATCBot
                 SetStatus(Status.Offline);
             }
 
-            Log.LogInfo("Shutting down! o7", announce: true);
+            Log.LogInfo("Shutting down! o7", systemMessageOption: Config.SystemMessageConfigOptions.Critical);
             if (forceDontSaveConfig)
                 return;
             Console.WriteLine("------");
@@ -407,7 +407,7 @@ namespace ATCBot
 
         private Task OnDisconnected(Exception e)
         {
-            Log.LogInfo("Discord has disconnected! Reason: " + e.Message, "Discord Client", true);
+            Log.LogInfo("Discord has disconnected! Reason: " + e.Message, "Discord Client", Config.SystemMessageConfigOptions.ConnectionStatus);
             WaitForReconnect();
 
 
@@ -421,7 +421,7 @@ namespace ATCBot
                 }
                 else
                 {
-                    Log.LogInfo("Reconnected. As a precaution, we will restart the lobby queries.", "Discord Client", true);
+                    Log.LogInfo("Reconnected. As a precaution, we will restart the lobby queries.", "Discord Client", Config.SystemMessageConfigOptions.ConnectionStatus);
                     lobbyHandler.ResetQueryTimer();
                 }
             }

--- a/ATCBot/Structs/JetborneLobby.cs
+++ b/ATCBot/Structs/JetborneLobby.cs
@@ -132,7 +132,7 @@ namespace ATCBot.Structs
 
             if (badKeys.Count > 0)
             {
-                Log.LogWarning($"One or more keys could not be set correctly! \"{string.Join(", ", badKeys.ToArray())}\"", "JBR Lobby Constructor", true);
+                Log.LogWarning($"One or more keys could not be set correctly! \"{string.Join(", ", badKeys.ToArray())}\"", "JBR Lobby Constructor");
                 this = default;
             }
             Log.LogDebug($"Found JBR Lobby | Name: {LobbyName} , Owner: {OwnerName} , Map: {Map} , Players: {PlayerCount}", "JBR Lobby Constructor");

--- a/ATCBot/Structs/VTOLLobby.cs
+++ b/ATCBot/Structs/VTOLLobby.cs
@@ -170,7 +170,7 @@ namespace ATCBot.Structs
 
             if (badKeys.Count > 0)
             {
-                Log.LogWarning($"One or more keys could not be set correctly! \"{string.Join(", ", badKeys.ToArray())}\"", "VTOL VR Lobby Constructor", true);
+                Log.LogWarning($"One or more keys could not be set correctly! \"{string.Join(", ", badKeys.ToArray())}\"", "VTOL VR Lobby Constructor");
                 this = default;
             }
             Log.LogDebug($"Found VTOL Lobby | Name: {LobbyName} , Owner: {OwnerName} , Scenario: {ScenarioName} , Players: {PlayerCount}/{MaxPlayers} , PP: {PasswordProtected()}",

--- a/ATCBot/Version.cs
+++ b/ATCBot/Version.cs
@@ -34,7 +34,7 @@ namespace ATCBot
             }
             catch (HttpRequestException e)
             {
-                Log.LogError("Could not get remote version!", e, "Version Checker", true);
+                Log.LogError("Could not get remote version!", e, "Version Checker");
                 RemoteVersion = "ERR";
             }
             return LocalVersion == RemoteVersion;

--- a/ATCBot/Watchdog.cs
+++ b/ATCBot/Watchdog.cs
@@ -59,7 +59,8 @@ namespace ATCBot
                             }
                             else
                             {
-                                Log.LogError($"Watchdog has detected a skipped heartbeat for the 5th time in a row! Trying to revive the query timer...", source: "Watchdog", announce: true);
+                                Log.LogError($"Watchdog has detected a skipped heartbeat for the 5th time in a row! Trying to revive the query timer...",
+                                    source: "Watchdog", systemMessageOption: Config.SystemMessageConfigOptions.Critical);
                                 Program.lobbyHandler.client.Disconnect();
                                 Program.lobbyHandler = new(program);
                                 _ = Program.lobbyHandler.QueryTimer(LobbyHandler.queryToken.Token);
@@ -78,7 +79,7 @@ namespace ATCBot
                 if(triedRestart)
                 {
                     triedRestart = false;
-                    Log.LogInfo("Watchdog seems to have successfully defibrillated the queries!", "Watchdog", true);
+                    Log.LogInfo("Watchdog seems to have successfully defibrillated the queries!", "Watchdog");
                 }
             }
 


### PR DESCRIPTION
- System message logs are now modular, meaning that types of logs can be toggled on and off depending on what the user wants to be output. **As this is a recent implementation it is possible that some log types are incorrectly set.**
- Adds a new command, `SetSystemMessageConfig` to set the types of config messages. Requires permission as usual.
- A default configuration is available for bots that upgrade beyond this; it is set up to be the most similar to the previous version (with verbose and debug off). However, some logs have been added either way

This PR edits many files and so may cause merge conflicts with its peers.