### PR TITLE
Fix version checker

### DIFF
--- a/ATCBot/Version.cs
+++ b/ATCBot/Version.cs
@@ -19,7 +19,7 @@ namespace ATCBot
         /// </summary>
         public static string RemoteVersion { get; private set; }
 
-        private static readonly string url = "https://gist.githubusercontent.com/Shadowtail117/507f77becaa1ea91a0caf6d1eca2e0ec/raw/c693ca7be928653c4f40c6d8b03d298f83cae13e/version.txt";
+        private static readonly string url = "https://gist.githubusercontent.com/Shadowtail117/507f77becaa1ea91a0caf6d1eca2e0ec/raw";
 
         /// <summary>
         /// Retrieve the remote version stored on the repository and verify it matches the local version.


### PR DESCRIPTION
- Fixes the version checker using only one version of the gist, resulting in a warning for anything other than 1.4.0p5