### PR TITLE
Add separate lobbies and hopefully add some stability

### DIFF
--- a/ATCBot/Config.cs
+++ b/ATCBot/Config.cs
@@ -59,9 +59,14 @@ namespace ATCBot
         public ConfigValue<ulong> vtolLobbyChannelId;
 
         /// <summary>
-        /// The Discord message ID of the last VTOL lobby information posting.
+        /// The Discord message ID of the last VTOL feature branch lobby information posting.
         /// </summary>
-        public ConfigValue<ulong> vtolLastMessageId;
+        public ConfigValue<ulong> vtolLastFeatureMessageID;
+
+        /// <summary>
+        /// The Discord message ID of the last VTOL public testing branch lobby information posting.
+        /// </summary>
+        public ConfigValue<ulong> vtolLastPTBMessageID;
 
         /// <summary>
         /// The Discord channel ID to post the Jetborne lobby information in.


### PR DESCRIPTION
Feature and PTB lobbies are now separated; if you use the same channel for all updates you should delete all preexisting messages for the formatting to look correct.

A lot of instances where the bot gets stuck showing empty lobbies stems from the matchmaking object in the lobby handler being null for some reason, so we will try to re-setup Steam (i.e. log back in) to try to fix that. This will only be attempted once; if it continues happening, we will just shut down with a critical error. This is experimental and not guaranteed to work but it's worth a shot; at the very least the bot will be clear that it is malfunctioning by shutting down.