### PR TITLE
1.4.0p9 prep

### DIFF
--- a/ATCBot/Version.cs
+++ b/ATCBot/Version.cs
@@ -12,7 +12,7 @@ namespace ATCBot
         /// <summary>
         /// The local version of the bot obtained from version.txt.
         /// </summary>
-        public static string LocalVersion { get; } = "1.4.0p8";
+        public static string LocalVersion { get; } = "1.4.0p9";
 
         /// <summary>
         /// The remote version on the repository.


### PR DESCRIPTION
Choo choo

Fix the feature branch embed being blank when the bot shuts down
Fix private lobbies not being shown at all
Fix "-1/x laps" for jetborne lobbies, it'll show that it's just in the lobby instead
Embeds are now always inline (lobbies are shown side by side) even when under 5 lobbies