### PR TITLE
Release 1.4.0p9

### DIFF
--- a/ATCBot/LobbyHandler.cs
+++ b/ATCBot/LobbyHandler.cs
@@ -251,13 +251,13 @@ namespace ATCBot
                 {
                     new Lobby.DistanceFilter(ELobbyDistanceFilter.Worldwide),
                     new Lobby.NumericalFilter("pwh", ELobbyComparison.NotEqual, 0),
-                    new Lobby.StringFilter("feature", ELobbyComparison.Equal, "f")
+                    new Lobby.StringFilter("feature", ELobbyComparison.Equal, "0")
                 };
                 var privatePTBOnly = new List<Lobby.Filter>
                 {
                     new Lobby.DistanceFilter(ELobbyDistanceFilter.Worldwide),
                     new Lobby.NumericalFilter("pwh", ELobbyComparison.NotEqual, 0),
-                    new Lobby.StringFilter("feature", ELobbyComparison.Equal, "p")
+                    new Lobby.StringFilter("feature", ELobbyComparison.Equal, "1")
                 };
 
                 SteamMatchmaking.GetLobbyListCallback vtolFeatureLobbiesRaw = null;

--- a/ATCBot/Program.cs
+++ b/ATCBot/Program.cs
@@ -381,7 +381,11 @@ namespace ATCBot
                     ptbEmbedBuilder.AddField("No lobbies!", "Check back later!");
             }
             else
+            {
+                featureEmbedBuilder.AddField("ATCBot is currently offline!", "Check back later!");
                 ptbEmbedBuilder.AddField("ATCBot is currently offline!", "Check back later!");
+            }
+
             return (featureEmbedBuilder, ptbEmbedBuilder);
         }
 
@@ -401,7 +405,7 @@ namespace ATCBot
                             Log.LogWarning("Invalid lobby state!", "JBR Embed Builder");
                             continue;
                         }
-                        string content = $"{lobby.Map}\n{lobby.PlayerCount} Player{(lobby.PlayerCount == 1 ? "" : "s")}\n{(lobby.CurrentLap == 0 ? "Currently In Lobby" : $"Lap { lobby.CurrentLap}/{ lobby.RaceLaps}")}";
+                        string content = $"{lobby.Map}\n{lobby.PlayerCount} Player{(lobby.PlayerCount == 1 ? "" : "s")}\n{(lobby.CurrentLap <= 0 ? "Currently In Lobby" : $"Lap { lobby.CurrentLap}/{ lobby.RaceLaps}")}";
                         jetborneEmbedBuilder.AddField(lobby.LobbyName, content, inline);
                     }
                 }

--- a/ATCBot/Program.cs
+++ b/ATCBot/Program.cs
@@ -312,8 +312,6 @@ namespace ATCBot
             EmbedBuilder ptbEmbedBuilder = new();
             ptbEmbedBuilder.WithColor(Color.DarkGrey).WithCurrentTimestamp().WithTitle("VTOL VR Public Testing Branch Lobbies:");
 
-            bool inline = lobbyHandler.vtolLobbies.Count > 5;
-
             if (!blank)
             {
                 //Feature lobbies
@@ -334,7 +332,7 @@ namespace ATCBot
                             $"\n{lobby.PlayerCount}/{lobby.MaxPlayers} Players" +
                             $"\n{gameState}{(gameState == GameState.Mission && lobby.METValid() ? $" ({lobby.MET})" : "")}" +
                             $"\nv{lobby.GameVersion}";
-                        featureEmbedBuilder.AddField(lobby.LobbyName, content, inline);
+                        featureEmbedBuilder.AddField(lobby.LobbyName, content, true);
                     }
 
                     if (LobbyHandler.PasswordedFeatureLobbies > 0)
@@ -366,7 +364,7 @@ namespace ATCBot
                             $"\n{lobby.PlayerCount}/{lobby.MaxPlayers} Players" +
                             $"\n{gameState}{(gameState == GameState.Mission && lobby.METValid() ? $" ({lobby.MET})" : "")}" +
                             $"\nv{lobby.GameVersion}";
-                        ptbEmbedBuilder.AddField(lobby.LobbyName, content, inline);
+                        ptbEmbedBuilder.AddField(lobby.LobbyName, content, true);
                     }
 
                     if (LobbyHandler.PasswordedPTBLobbies > 0)
@@ -397,7 +395,6 @@ namespace ATCBot
             {
                 if (lobbyHandler.jetborneLobbies.Count > 0)
                 {
-                    bool inline = lobbyHandler.jetborneLobbies.Count > 5;
                     foreach (JetborneLobby lobby in lobbyHandler.jetborneLobbies)
                     {
                         if (lobby.OwnerName == string.Empty || lobby.LobbyName == string.Empty)
@@ -406,7 +403,7 @@ namespace ATCBot
                             continue;
                         }
                         string content = $"{lobby.Map}\n{lobby.PlayerCount} Player{(lobby.PlayerCount == 1 ? "" : "s")}\n{(lobby.CurrentLap <= 0 ? "Currently In Lobby" : $"Lap { lobby.CurrentLap}/{ lobby.RaceLaps}")}";
-                        jetborneEmbedBuilder.AddField(lobby.LobbyName, content, inline);
+                        jetborneEmbedBuilder.AddField(lobby.LobbyName, content, true);
                     }
                 }
                 else

--- a/ATCBot/Version.cs
+++ b/ATCBot/Version.cs
@@ -12,7 +12,7 @@ namespace ATCBot
         /// <summary>
         /// The local version of the bot obtained from version.txt.
         /// </summary>
-        public static string LocalVersion { get; } = "1.4.0p8";
+        public static string LocalVersion { get; } = "1.4.0p9";
 
         /// <summary>
         /// The remote version on the repository.


### PR DESCRIPTION
Fast release for fast fixes.

- Fix VTOL VR feature embed being blank after shutting down.
- Fix private lobbies not being shown.
- Fix "-1/x" laps in the Jetborne Racing embeds.
- Embeds are now always inline, meaning lobbies are displayed side by side when possible.


This should hopefully be one of, if not the last release before the actual 1.4.0.