### PR TITLE
Fix potential cause of hanging

### DIFF
--- a/ATCBot/LobbyHandler.cs
+++ b/ATCBot/LobbyHandler.cs
@@ -63,7 +63,7 @@ namespace ATCBot
                 if(triedLoggingIn) Log.LogInfo("Updating lobbies...", "Lobby Handler");
                 manager.RunWaitCallbacks(TimeSpan.FromSeconds(Program.config.steamTimeout));
                 await GetLobbies();
-                await program.UpdateInformation();
+                _ = program.UpdateInformation();
                 Watchdog.lastUpdate = DateTime.Now;
             }
             else if (triedLoggingIn) Log.LogInfo("Skipping update...", "Lobby Handler");


### PR DESCRIPTION
Discord messsage edits are no longer awaited, which seems to have been a major cause of the hanging. Could this finally be it?