### PR TITLE
Update Discord.Net

### DIFF
--- a/ATCBot/ATCBot.csproj
+++ b/ATCBot/ATCBot.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Labs" Version="3.6.1" />
+    <PackageReference Include="Discord.Net" Version="3.8.1" />
     <PackageReference Include="SteamKit2" Version="2.4.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated Discord.Net to 3.8.1, and off of the now-deprecated Labs version. This should fix errors with forum channels.